### PR TITLE
Remove PROJECT_BASE_URL and document changes

### DIFF
--- a/basic.docker.env
+++ b/basic.docker.env
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+### PROJECT SETTINGS
+
+PROJECT_NAME=
+PROJECT_BASE_PATH=
+MARIADB_TAG=10.3-3.4.11
+PHP_TAG=7.3-dev-4.12.12
+# macOS
+#PHP_TAG=7.3-dev-macos-4.12.12
+APACHE_TAG=2.4-4.0.7
+DB_NAME=db
+DB_USER=db
+DB_PASSWORD=db
+DB_ROOT_PASSWORD=root
+DB_HOST=mariadb
+DB_DRIVER=mysql

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -49,7 +49,7 @@ services:
     labels:
       # Minimal modifications to allow subdomain wildcard. Any URL that does not match with
       # taken domains like pma."project".localhost will fall intro apache container.
-      traefik.frontend.rule: HostRegexp:${PROJECT_BASE_URL}, {subdomain:[a-z]+}.${PROJECT_BASE_URL}
+      traefik.frontend.rule: HostRegexp:${PROJECT_NAME}.localhost, {subdomain:[a-z]+}.${PROJECT_NAME}.localhost
 
   pma:
     network_mode: traefik_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     labels:
       - 'traefik.backend=${PROJECT_NAME}_mailhog'
       - 'traefik.port=8025'
-      - 'traefik.frontend.rule=Host:mailhog.${PROJECT_BASE_URL}'
+      - 'traefik.frontend.rule=Host:mailhog.${PROJECT_NAME}.localhost'
 
   apache:
     image: wodby/apache:$APACHE_TAG
@@ -73,7 +73,7 @@ services:
     labels:
       - 'traefik.backend=${PROJECT_NAME}_apache'
       - 'traefik.port=80'
-      - 'traefik.frontend.rule=Host:${PROJECT_BASE_URL}'
+      - 'traefik.frontend.rule=Host:${PROJECT_NAME}.localhost'
 
   pma:
     image: phpmyadmin/phpmyadmin
@@ -87,4 +87,4 @@ services:
     labels:
       - 'traefik.backend=${PROJECT_NAME}_pma'
       - 'traefik.port=80'
-      - 'traefik.frontend.rule=Host:pma.${PROJECT_BASE_URL}'
+      - 'traefik.frontend.rule=Host:pma.${PROJECT_NAME}.localhost'

--- a/docs/docs/dockerenv.md
+++ b/docs/docs/dockerenv.md
@@ -1,12 +1,11 @@
 # .docker.env file
 
-This is the shared docker configuration file. On it you can configure things like PHP version, MySQL version, PHP, settings an all you need to fit the project into the docker.
+This is the shared docker configuration file. You can configure things like PHP version, MySQL version, PHP, settings and all you need to fit the project into the docker.
 
 ## General 
 | PROJECT VARS                      | MEANING                                    | |
 |--------------------------|--------------------------------------------|--------------------------------------------------------------------------------------------|
 | PROJECT_NAME             | The project base name                      | Needs to be customized                                                                     |
-| PROJECT_BASE_URL         | The project url                            | Needs to be customized                                                                     |
 | PROJECT_BASE_PATH        | Base project's path                        | If your project resides in a subdir you can specify it on PROJECT_BASE_PATH                |
 
 ## PHP specific
@@ -36,6 +35,6 @@ The MariaDB default values ( defined in `docker-compose.override.yml` ) are conf
 For the rest of available variables please see  [https://github.com/wodby/docker4drupal](https://github.com/wodby/docker4drupal)
 
 ## Modifying variables just for you
-Since `.docker.env` is a common shared file you will not be able to make personal modifications on it. For this king of customizations you have `.docker.override.env`  
+Since `.docker.env` is a common shared file you will not be able to make personal modifications on it. For this kind of customizations you should use `.docker.override.env`
 
 `.docker.override.env` should be never committed since it is only for you and your environment. The usage is really simple. Just put in there the variables you want to override with the new value like in the original `.docker.env` file.

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -5,9 +5,15 @@ A brief of what install script will do:
 * Installs a traefik service (at `/usr/local/bin/dk_traefik`).  
 * Installs `dk` cli.
 
-To install dockerizer run:
+To install dockerizer run ( depending on your system configuration):
 ```bash
+
 bash <(curl -s https://raw.githubusercontent.com/frontid/dockerizer/master/install.sh)
+
+OR
+
+bash <(wget -O - https://raw.githubusercontent.com/frontid/dockerizer/master/install.sh)
+
 dk start traefik
 ```
 
@@ -22,7 +28,7 @@ git clone git@github.com:YOU/YOUR-PROJECT.git web
 
 Next you need "dockerize" a project. To accomplish that the only thing you need to do is  create `.docker.env` and commit the preferences on the file.  
 Dockerizer provides you an example. Copy `example.docker.env` as `.docker.env` at your "web" dir and configure it (See **[.docker.env](/dockerenv)** documentation for a more detailed explanation). 
-
+We provide a basic.docker.env for impatient people, where you only have to change PROJECT_NAME to suit your needs.
 That's all, now run `dk start` and happy coding!
 
 # Run a configured project

--- a/docs/docs/troubleshoot.md
+++ b/docs/docs/troubleshoot.md
@@ -1,5 +1,5 @@
 # I can't connect to the DB as I was doing it on my localhost
-Since the DB it's a independent container, the right way to connect to it is point to the remote container like this:
+Since the DB it's an independent container, the right way to connect to it is pointing to the remote container like this:
 
 ```
 'database' => '[DB_NAME]',
@@ -34,15 +34,15 @@ We should connect from our web project using this config:
 
 # Chrome shows me "Your connection is not private" when I try to enter to the https dockerized page.
 
-Since dockerizer provides a self signed certificate to allow https localhost development, iy's common to see a warning link this:
+Since dockerizer provides a self signed certificate allowing https localhost development, it's likely you'll find a warning like this:
 
 [![](img/your-connection-is-not-private.png)](img/your-connection-is-not-private.png)
 
-The solution at chrome is to open a new tab and paste this command: `chrome://flags/#allow-insecure-localhost` mark the option to "enabled" and restart the browser:
+The solution for Chrome is opening a new tab and paste this command: `chrome://flags/#allow-insecure-localhost` mark the option to "enabled" and restart the browser:
 
 [![](img/conf-chrome-allow-https-self-signed.png) ](img/conf-chrome-allow-https-self-signed.png)
 
-Now chrome will show the page without prompting you with "Your connection is not private" anymore.
+Now Chrome will show the page without prompting you with "Your connection is not private" anymore.
 
 # I want PhpStorm stop debugging drush!
 
@@ -53,7 +53,7 @@ Just disable those options at your PhpStorm settings and you are done.
 
 # How can I debug drush scripts in drupal 8?
 
-Due to drupal-launcher loses it's mind when you are trying to debug a script. You need to bypass it calling directly the real drush command like this:
+Due to drupal-launcher loses its mind when you are trying to debug a script , you need to bypass it calling directly the real drush command like this:
 
 `cmd php ./vendor/drush/drush/drush foo:command` 
 

--- a/example.docker.env
+++ b/example.docker.env
@@ -2,9 +2,12 @@
 ### PROJECT SETTINGS
 
 PROJECT_NAME=dockerizer
-PROJECT_BASE_URL=dockerizer.localhost
-# If your project resides in a subdir you can specify it on PROJECT_BASE_PATH
+# If your project resides in a subdir of the "web" folder you can specify it on PROJECT_BASE_PATH
 PROJECT_BASE_PATH=
+
+
+# ----------------------------------------------------------------------------
+### DB SETTINGS
 
 DB_NAME=db
 DB_USER=db
@@ -17,20 +20,19 @@ DB_DRIVER=mysql
 ### --- MARIADB ----
 
 MARIADB_TAG=10.3-3.4.11
-#MARIADB_TAG=10.3-3.4.11
 #MARIADB_TAG=10.1-3.4.11
 
 # ----------------------------------------------------------------------------
 ### --- PHP ----
 
-# Linux (uid 1000 gid 1000)
+# Linux
 
 PHP_TAG=7.3-dev-4.12.12
 #PHP_TAG=7.2-dev-4.12.12
 #PHP_TAG=7.1-dev-4.12.12
 #PHP_TAG=5.6-dev-4.12.12
 
-# macOS (uid 501 gid 20)
+# macOS
 
 #PHP_TAG=7.3-dev-macos-4.12.12
 #PHP_TAG=7.2-dev-macos-4.12.12
@@ -38,9 +40,13 @@ PHP_TAG=7.3-dev-4.12.12
 #PHP_TAG=5.6-dev-macos-4.12.12
 
 # ----------------------------------------------------------------------------
-### OTHERS
+###  --- APACHE ----
 
 APACHE_TAG=2.4-4.0.7
+
+# ----------------------------------------------------------------------------
+### Postgres
+#POSTGRESS_TAG=latest
 
 # ----------------------------------------------------------------------------
 ### --- CUSTOM VARS ----
@@ -61,6 +67,3 @@ APACHE_TAG=2.4-4.0.7
 #MYSQL_OPTIMIZER_SEARCH_DEPTH=0
 #MYSQL_QUERY_CACHE_TYPE=0
 #MYSQL_QUERY_CACHE_SIZE=0
-
-# Dockerizer customs
-POSTGRESS_TAG=latest


### PR DESCRIPTION
While I tried to remove all the unneeded env variables to simplify the
DK configuration, I found that when a variable is set like this in any
of the .yml files :

APACHE_DOCUMENT_ROOT: /var/www/html/web/$PROJECT_BASE_PATH

the value "$PROJECT_BASE_URL" has to be defined in the .env file ( or at
runtime with CLI vars )

You can't define this var inside the service like this before using it :

PROJECT_BASE_PATH : ${PROJECT_BASE_PATH:-public}

as docker-compose expects the env vars used to be already defined.

The docs have been updated to reflect these changes, and some typos have
been also fixed